### PR TITLE
CLD-710 Add SSL support for HAproxy and HTTP to HTTPS redirect 

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -30,6 +30,8 @@ defaults
 
 frontend rgw-frontend
     bind *:{{ haproxy_frontend_port }}
+    bind *:443 ssl crt {{ hosting_domain_ssl_fullchain_directory }}/{{ hosting_domain_ssl_fullchain_filename }}
+    http-request redirect scheme https unless { ssl_fc }
     default_backend rgw-backend
 
 backend rgw-backend


### PR DESCRIPTION
**Summary**

- Add SSL support for HAproxy via hardcode
- Add HTTP to HTTPS redirect

**Test**

```
stanleylam@controller001-prod:~$ sudo aws s3 --endpoint-url=http://radosgw-prod.core-x.net ls
2019-10-31 08:41:27 test-bucket

stanleylam@controller001-prod:~$ sudo aws s3 --endpoint-url=https://radosgw-prod.core-x.net ls
2019-10-31 08:41:27 test-bucket
```