### PR TITLE
CLD-699 Add advanced keepalived configuration

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -13,20 +13,10 @@ haproxy_frontend_ssl_termination: False
 #  - address: 192.168.238.250
 #    netmask: 16
 #    interface: br-storage
-#    multicast_address: ""
-#    virtual_route_gateway: ""
-#    virtual_route_source: ""
+#    virtual_route_gateway:
+#    virtual_route_source:
 #  - address: 192.168.238.251
 #    netmask: 24
 #    interface: br-provider1
-#    multicast_address: ""
-#    virtual_route_gateway: ""
-#    virtual_route_source: ""
-
-#
-#virtual_ips:
-#   - 192.168.238.250
-#   - 192.168.238.251
-#
-#virtual_ip_netmask: 24
-#virtual_ip_interface: ens33
+#    virtual_route_gateway:
+#    virtual_route_source:

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -11,12 +11,12 @@ haproxy_frontend_ssl_termination: False
 
 #virtual_ips:
 #  - address: 192.168.238.250
-#    netmask: 16
-#    interface: br-storage
+#    netmask: 24
+#    interface: ens33
 #    virtual_route_gateway:
 #    virtual_route_source:
-#  - address: 192.168.238.251
+#  - address: 192.168.1.250
 #    netmask: 24
-#    interface: br-provider1
+#    interface: ens34
 #    virtual_route_gateway:
 #    virtual_route_source:

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -8,6 +8,21 @@
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_termination: False
+
+#virtual_ips:
+#  - address: 192.168.238.250
+#    netmask: 16
+#    interface: br-storage
+#    multicast_address: ""
+#    virtual_route_gateway: ""
+#    virtual_route_source: ""
+#  - address: 192.168.238.251
+#    netmask: 24
+#    interface: br-provider1
+#    multicast_address: ""
+#    virtual_route_gateway: ""
+#    virtual_route_source: ""
+
 #
 #virtual_ips:
 #   - 192.168.238.250

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -18,5 +18,5 @@ haproxy_frontend_ssl_termination: False
 #  - address: 192.168.1.250
 #    netmask: 24
 #    interface: ens34
-#    virtual_route_gateway:
-#    virtual_route_source:
+#    virtual_route_gateway: 192.168.1.254
+#    virtual_route_source: 10.10.10.1

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -19,4 +19,7 @@ haproxy_frontend_ssl_termination: False
 #    netmask: 24
 #    interface: ens34
 #    virtual_route_gateway: 192.168.1.254
-#    virtual_route_source: 10.10.10.1
+#    virtual_route_source:
+#      - 10.10.10.1
+#      - 10.10.10.2
+#      - 10.10.10.3

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'multicast_address': item.multicast_address, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -20,8 +20,7 @@
 - name: set_fact vip to vrrp_instance
   set_fact:
       vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
-#  loop: "{{ virtual_ips | flatten(levels=1) }}"
-  loop: "{{ virtual_ips }}"
+  loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index
 

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'multicast_address': item.multicast_address, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -20,7 +20,8 @@
 - name: set_fact vip to vrrp_instance
   set_fact:
       vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
-  loop: "{{ virtual_ips | flatten(levels=1) }}"
+#  loop: "{{ virtual_ips | flatten(levels=1) }}"
+  loop: "{{ virtual_ips }}"
   loop_control:
       index_var: index
 

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][0] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item, 'netmask': item.netmask, 'interface': item.interface, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item, 'netmask': item.netmask, 'interface': item.interface, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source, 'master': groups[rgwloadbalancer_group_name][0] }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
       index_var: index

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -32,7 +32,7 @@ vrrp_instance {{ instance['name'] }} {
     virtual_routes {
   {%- for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {%- endfor %}
+  {%- endfor %}{{ '\n' }}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -27,6 +27,9 @@ vrrp_instance {{ instance['name'] }} {
     virtual_ipaddress {
         {{ instance['vip'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
     }
+{% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
+    {{ instance['virtual_route_source'] }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
+{% endif %}
     track_script {
         check_haproxy
     }

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -25,7 +25,7 @@ vrrp_instance {{ instance['name'] }} {
         auth_pass 1234
     }
     virtual_ipaddress {
-        {{ instance['vip'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
+        {{ instance['address'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
     }
     track_script {
         check_haproxy

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -32,7 +32,7 @@ vrrp_instance {{ instance['name'] }} {
     virtual_routes {
   {%- for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {%- endfor %}    }
+  {%- endfor %}{{ '\n' }}    }
 {% endif %}
     track_script {
         check_haproxy

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -30,7 +30,9 @@ vrrp_instance {{ instance['name'] }} {
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
-        {{ instance['virtual_route_source'] }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
+  {% for source in instance['virtual_route_source'] %} 
+        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
+  {% endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -15,8 +15,10 @@ vrrp_script check_haproxy {
 
 {% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
-    state {{ 'MASTER' if ansible_hostname == instance['master'] else 'BACKUP' }}
-    priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
+    #state {{ 'MASTER' if ansible_hostname == instance['master'] else 'BACKUP' }}
+    #priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
+    state {{ 'MASTER' if ansible_hostname == groups.rgwloadbalancers.0 else 'BACKUP' }}
+    priority {{ '100' if ansible_hostname == groups.rgwloadbalancers.0 else '90' }}
     interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
     garp_master_delay 10

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -32,8 +32,7 @@ vrrp_instance {{ instance['name'] }} {
     virtual_routes {
   {%- for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {%- endfor %}{{ '\n' }}
-    }
+  {%- endfor %}    }
 {% endif %}
     track_script {
         check_haproxy

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -25,7 +25,7 @@ vrrp_instance {{ instance['name'] }} {
         auth_pass 1234
     }
     virtual_ipaddress {
-        {{ instance['vip'] }}/{{ virtual_ip_netmask }} dev {{ virtual_ip_interface }}
+        {{ instance['vip'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
     }
     track_script {
         check_haproxy

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -15,8 +15,8 @@ vrrp_script check_haproxy {
 
 {% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
-    state {{ 'MASTER' if ansible_hostname == controller002-stg.core-x.net else 'BACKUP' }}
-    priority {{ '100' if ansible_hostname == controller002-stg.core-x.net else '90' }}
+    state {{ 'MASTER' if ansible_hostname == 'controller002-stg.core-x.net' else 'BACKUP' }}
+    priority {{ '100' if ansible_hostname == 'controller002-stg.core-x.net' else '90' }}
     interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
     garp_master_delay 10

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -30,9 +30,9 @@ vrrp_instance {{ instance['name'] }} {
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
-  {% for source in instance['virtual_route_source'] %} 
+  {% for source in instance['virtual_route_source'] -%} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {% endfor %}
+  {%- endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -17,8 +17,8 @@ vrrp_script check_haproxy {
 vrrp_instance {{ instance['name'] }} {
     #state {{ 'MASTER' if ansible_hostname == instance['master'] else 'BACKUP' }}
     #priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
-    state {{ 'MASTER' if ansible_hostname == groups.rgwloadbalancers.0 else 'BACKUP' }}
-    priority {{ '100' if ansible_hostname == groups.rgwloadbalancers.0 else '90' }}
+    state {{ 'MASTER' if ansible_hostname == groups['rgwloadbalancers'][0] else 'BACKUP' }}
+    priority {{ '100' if ansible_hostname == groups['rgwloadbalancers'][0] else '90' }}
     interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
     garp_master_delay 10

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -30,7 +30,7 @@ vrrp_instance {{ instance['name'] }} {
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
-  {% for source in instance['virtual_route_source'] -%} 
+  {% for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
   {% endfor %}
     }

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -31,7 +31,7 @@ vrrp_instance {{ instance['name'] }} {
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
   {% for source in instance['virtual_route_source'] %} 
-        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
+        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
   {%- endfor %}
     }
 {% endif %}

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -30,8 +30,8 @@ vrrp_instance {{ instance['name'] }} {
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
-  {% for source in instance['virtual_route_source'] %} 
-        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
+  {%- for source in instance['virtual_route_source'] %} 
+        {{- source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
   {%- endfor %}
     }
 {% endif %}

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -32,7 +32,7 @@ vrrp_instance {{ instance['name'] }} {
     virtual_routes {
   {% for source in instance['virtual_route_source'] -%} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {%- endfor %}
+  {% endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -28,7 +28,9 @@ vrrp_instance {{ instance['name'] }} {
         {{ instance['vip'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
-    {{ instance['virtual_route_source'] }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
+    virtual_routes {
+        {{ instance['virtual_route_source'] }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
+    }
 {% endif %}
     track_script {
         check_haproxy

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -31,8 +31,8 @@ vrrp_instance {{ instance['name'] }} {
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
   {% for source in instance['virtual_route_source'] %} 
-        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {% endfor %}
+        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
+  {%- endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -30,9 +30,9 @@ vrrp_instance {{ instance['name'] }} {
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
-  {% for source in instance['virtual_route_source'] %} 
+  {%- for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
-  {% endfor %}
+  {%- endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -31,8 +31,8 @@ vrrp_instance {{ instance['name'] }} {
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
   {% for source in instance['virtual_route_source'] %} 
-        {{- source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
-  {%- endfor %}
+        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
+  {% endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -30,8 +30,8 @@ vrrp_instance {{ instance['name'] }} {
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
-  {%- for source in instance['virtual_route_source'] %} 
-        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
+  {% for source in instance['virtual_route_source'] %} 
+        {{- source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
   {%- endfor %}
     }
 {% endif %}

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -19,6 +19,7 @@ vrrp_instance {{ instance['name'] }} {
     priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
     interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
+    garp_master_delay 10
     advert_int 1
     authentication {
         auth_type PASS

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -15,10 +15,8 @@ vrrp_script check_haproxy {
 
 {% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
-    #state {{ 'MASTER' if ansible_hostname == instance['master'] else 'BACKUP' }}
-    #priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
-    state {{ 'MASTER' if ansible_hostname == groups['rgwloadbalancers'][0] else 'BACKUP' }}
-    priority {{ '100' if ansible_hostname == groups['rgwloadbalancers'][0] else '90' }}
+    state {{ 'MASTER' if ansible_hostname == groups[rgwloadbalancer_group_name][0] else 'BACKUP' }}
+    priority {{ '100' if ansible_hostname == groups[rgwloadbalancer_group_name][0] else '90' }}
     interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
     garp_master_delay 10

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -32,7 +32,7 @@ vrrp_instance {{ instance['name'] }} {
     virtual_routes {
   {%- for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {%- endfor %}{{ '\n' }}
+  {% endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -32,7 +32,7 @@ vrrp_instance {{ instance['name'] }} {
     virtual_routes {
   {%- for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
-  {% endfor %}
+  {%- endfor %}
     }
 {% endif %}
     track_script {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -17,7 +17,7 @@ vrrp_script check_haproxy {
 vrrp_instance {{ instance['name'] }} {
     state {{ 'MASTER' if ansible_hostname == instance['master'] else 'BACKUP' }}
     priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
-    interface {{ virtual_ip_interface }}
+    interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
     advert_int 1
     authentication {

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -25,7 +25,7 @@ vrrp_instance {{ instance['name'] }} {
         auth_pass 1234
     }
     virtual_ipaddress {
-        {{ instance['address'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
+        {{ instance['vip'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
     }
     track_script {
         check_haproxy

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -15,8 +15,8 @@ vrrp_script check_haproxy {
 
 {% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
-    state {{ 'MASTER' if ansible_hostname == 'controller002-stg.core-x.net' else 'BACKUP' }}
-    priority {{ '100' if ansible_hostname == 'controller002-stg.core-x.net' else '90' }}
+    state {{ 'MASTER' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else 'BACKUP' }}
+    priority {{ '100' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else '90' }}
     interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
     garp_master_delay 10

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -31,7 +31,7 @@ vrrp_instance {{ instance['name'] }} {
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
   {%- for source in instance['virtual_route_source'] %} 
-        {{- source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
+        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
   {%- endfor %}
     }
 {% endif %}

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -31,7 +31,7 @@ vrrp_instance {{ instance['name'] }} {
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
   {%- for source in instance['virtual_route_source'] %} 
-        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n' }}
+        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
   {%- endfor %}
     }
 {% endif %}

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -15,8 +15,8 @@ vrrp_script check_haproxy {
 
 {% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
-    state {{ 'MASTER' if ansible_hostname == groups[rgwloadbalancer_group_name][0] else 'BACKUP' }}
-    priority {{ '100' if ansible_hostname == groups[rgwloadbalancer_group_name][0] else '90' }}
+    state {{ 'MASTER' if ansible_hostname == controller002-stg.core-x.net else 'BACKUP' }}
+    priority {{ '100' if ansible_hostname == controller002-stg.core-x.net else '90' }}
     interface {{ instance['interface'] }}
     virtual_router_id {{ 50 + loop.index }}
     garp_master_delay 10


### PR DESCRIPTION
**Summary**

- Add configurations for `/etc/keepalived/keepalived.conf` to allow virtual ip addresses to be associated with different interfaces.

- Add optional `virtual routes` configuration for  `/etc/keepalived/keepalived.conf`, with ability to specify gateway and multiple source addresses.

- Hardcoded `garp_master_delay` to 10 seconds from default of 5 seconds.

- Modified how` MASTER` is chosen for keepalived to use `inventory_hostname` to match with the first host on `rgwloadbalancer_group_name`.

**Tests**

- `/etc/keepalived/keepalived.conf`:
```
vrrp_instance VI_0 {
    state MASTER
    priority 100
    interface br-storage
    virtual_router_id 51
    garp_master_delay 10
    advert_int 1
    authentication {
        auth_type PASS
        auth_pass REDACTED
    }
    virtual_ipaddress {
        10.206.0.8/16 dev br-storage
    }
    track_script {
        check_haproxy
    }
}

vrrp_instance VI_1 {
    state MASTER
    priority 100
    interface br-provider1
    virtual_router_id 52
    garp_master_delay 10
    advert_int 1
    authentication {
        auth_type PASS
        auth_pass REDACTED
    }
    virtual_ipaddress {
        REDACTED/24 dev br-provider1
    }
    virtual_routes {
        REDACTED via REDACTED dev br-provider1
        REDACTED via REDACTED dev br-provider1
        REDACTED via REDACTED dev br-provider1
    track_script {
        check_haproxy
    }
```
- Confirmed connection to RGW via HTTPS:
```
curl https://radosgw-staging.core-x.net
<?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>anonymous</ID><DisplayName></DisplayName></Owner><Buckets></Buckets></ListAllMyBucketsResult>
```