### PR TITLE
CLD-699 Add additional SSL security measures for HAproxy

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -9,6 +9,12 @@ global
     group       haproxy
     daemon
     stats socket /var/lib/haproxy/stats
+    stats socket /var/lib/haproxy/stats
+{% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
+    tune.ssl.default-dh-param 4096
+    ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM
+    ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+{% endif %}
 
 defaults
     mode                    http
@@ -29,10 +35,10 @@ defaults
     maxconn                 8000
 
 frontend rgw-frontend
-    bind *:{{ haproxy_frontend_port }}
 {% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
     bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ radosgw_frontend_ssl_certificate }}
-    redirect scheme https code 301 if !{ ssl_fc }
+{% else %}
+    bind *:{{ haproxy_frontend_port }}
 {% endif %}
     default_backend rgw-backend
 

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -9,7 +9,6 @@ global
     group       haproxy
     daemon
     stats socket /var/lib/haproxy/stats
-    stats socket /var/lib/haproxy/stats
 {% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
     tune.ssl.default-dh-param 4096
     ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM


### PR DESCRIPTION
**Summary**

- Add increased security to `haproxy.cfg` based on https://xneelo.atlassian.net/browse/CLD-747

- Remove HTTP to HTTPS redirect in `haproxy.cfg`

**Tests**

Run `ansible-playbook -i staging.ini ceph-ansible/site.yml.sample`:
```
PLAY RECAP ********************************************************************************************
controller001-stg.core-x.net : ok=91   changed=4    unreachable=0    failed=0    skipped=189  rescued=0    ignored=0
controller002-stg.core-x.net : ok=256  changed=9    unreachable=0    failed=0    skipped=379  rescued=0    ignored=0
controller003-stg.core-x.net : ok=237  changed=8    unreachable=0    failed=0    skipped=358  rescued=0    ignored=0
controller004-stg.core-x.net : ok=293  changed=9    unreachable=0    failed=0    skipped=426  rescued=0    ignored=0
storage001-stg             : ok=0    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
storage001-stg.core-x.net  : ok=97   changed=3    unreachable=0    failed=0    skipped=201  rescued=0    ignored=0
storage002-stg             : ok=0    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
storage002-stg.core-x.net  : ok=93   changed=2    unreachable=0    failed=0    skipped=197  rescued=0    ignored=0
storage003-stg             : ok=0    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
storage003-stg.core-x.net  : ok=93   changed=2    unreachable=0    failed=0    skipped=197  rescued=0    ignored=0
```
- `haproxy.cfg`:
```
global
    log         127.0.0.1 local2

    chroot      /var/lib/haproxy
    pidfile     /var/run/haproxy.pid
    maxconn     8000
    user        haproxy
    group       haproxy
    daemon
    stats socket /var/lib/haproxy/stats
    tune.ssl.default-dh-param 4096
    ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM
    ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets

defaults
    mode                    http
    log                     global
    option                  httplog
    option                  dontlognull
    option http-server-close
    option forwardfor       except 127.0.0.0/8
    option                  redispatch
    retries                 3
    timeout http-request    10s
    timeout queue           1m
    timeout connect         10s
    timeout client          1m
    timeout server          1m
    timeout http-keep-alive 10s
    timeout check           10s
    maxconn                 8000

frontend rgw-frontend
    bind *:443 ssl crt /etc/ssl/core-x.net/core-x-fullchain.pem
    default_backend rgw-backend

backend rgw-backend
    option forwardfor
    balance static-rr
    option httpchk Get /
        server server-controller002-stg-rgw0 REDACTED weight 100
        server server-controller003-stg-rgw0 REDACTED weight 100
        server server-controller004-stg-rgw0 REDACTED weight 100
```
- Confirm working:
```
sudo aws s3 --endpoint-url=https://radosgw-stg.core-x.net ls
2019-10-29 17:10:53 test-bucket
```