### PR TITLE
CLD-801 Add support to download specific keepalived version

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -5,6 +5,9 @@
 # GENERAL #
 ###########
 
+keepalived_url: "https://www.keepalived.org/software/keepalived-{{ keepalived_version }}.tar.gz"
+keepalived_version: distro
+
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_termination: False

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -23,16 +23,16 @@
 - name: install non-distro version of keepalived
   block:
 
+    - name: install required packages for keepalived
+      apt:
+        name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev']
+        state: present
+
     - name: check if specified keepalived version already exists
       command: "ls /usr/sbin/keepalived-{{ keepalived_version }}"
       failed_when: false
       changed_when: false
       register: check_keepalived_version
-
-    - name: install required packages for keepalived
-      apt:
-        name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev']
-        state: present
 
     - name: unarchive keepalived
       unarchive:
@@ -41,20 +41,19 @@
         remote_src: true
         owner: root
         group: root
+      when: check_keepalived_version.rc != 0
 
     - name: build keepalived
       command: "./configure --prefix=/usr/sbin/keepalived-{{ keepalived_version }}"
       args:
         chdir: "/tmp/keepalived-{{ keepalived_version }}/"
-      when:
-        - check_keepalived_version.rc != 0
+      when: check_keepalived_version.rc != 0
 
     - name: install keepalived
       make:
         chdir: "/tmp/keepalived-{{ keepalived_version }}/"
         target: install
-      when:
-        - check_keepalived_version.rc != 0
+      when: check_keepalived_version.rc != 0
 
     - name: update binary to updated keepalived version
       file:
@@ -62,9 +61,7 @@
         src: "/usr/sbin/keepalived-{{ keepalived_version }}/sbin/keepalived"
         state: link
         force: true
-  when:
-    - keepalived_version is defined
-    - keepalived_version != 'distro'
+  when: keepalived_version != 'distro'
 
 - name: "generate haproxy configuration file: haproxy.cfg"
   template:

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -25,51 +25,42 @@
   failed_when: false
   changed_when: false
   register: check_keepalived_version
-  when:
 
-- name: install required packages for keepalived
-  apt:
-    name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev' ]
-    state: present
-  when:
-    - keepalived_version is defined
-    - keepalived_version != 'distro'
+- name: install non-distro version of keepalived
+  block:
+    - name: install required packages for keepalived
+      apt:
+        name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev']
+        state: present
 
-- name: unarchive keepalived
-  unarchive:
-    src: "{{ keepalived_url }}"
-    dest: /tmp/
-    remote_src: true
-    owner: root
-    group: root
-  when:
-    - keepalived_version is defined
-    - keepalived_version != 'distro'
+    - name: unarchive keepalived
+      unarchive:
+        src: "{{ keepalived_url }}"
+        dest: /tmp/
+        remote_src: true
+        owner: root
+        group: root
 
-- name: build keepalived
-  command: "./configure --prefix=/usr/sbin/keepalived-{{ keepalived_version }}"
-  args:
-    chdir: "/tmp/keepalived-{{ keepalived_version }}/"
-  when:
-    - check_keepalived_version.rc != 0
-    - keepalived_version is defined
-    - keepalived_version != 'distro'
+    - name: build keepalived
+      command: "./configure --prefix=/usr/sbin/keepalived-{{ keepalived_version }}"
+      args:
+        chdir: "/tmp/keepalived-{{ keepalived_version }}/"
+      when:
+        - check_keepalived_version.rc != 0
 
-- name: install keepalived
-  make:
-    chdir: "/tmp/keepalived-{{ keepalived_version }}/"
-    target: install
-  when:
-    - check_keepalived_version.rc != 0
-    - keepalived_version is defined
-    - keepalived_version != 'distro'
+    - name: install keepalived
+      make:
+        chdir: "/tmp/keepalived-{{ keepalived_version }}/"
+        target: install
+      when:
+        - check_keepalived_version.rc != 0
 
-- name: update binary to updated keepalived version
-  file:
-    path: /usr/sbin/keepalived
-    src: "/usr/sbin/keepalived-{{ keepalived_version }}/sbin/keepalived"
-    state: link
-    force: true
+    - name: update binary to updated keepalived version
+      file:
+        path: /usr/sbin/keepalived
+        src: "/usr/sbin/keepalived-{{ keepalived_version }}/sbin/keepalived"
+        state: link
+        force: true
   when:
     - keepalived_version is defined
     - keepalived_version != 'distro'

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -20,14 +20,15 @@
   when: keepalived_version == 'distro'
   until: result is succeeded
 
-- name: check if specified keepalived version already exists
-  command: "ls /usr/sbin/keepalived-{{ keepalived_version }}"
-  failed_when: false
-  changed_when: false
-  register: check_keepalived_version
-
 - name: install non-distro version of keepalived
   block:
+
+    - name: check if specified keepalived version already exists
+      command: "ls /usr/sbin/keepalived-{{ keepalived_version }}"
+      failed_when: false
+      changed_when: false
+      register: check_keepalived_version
+
     - name: install required packages for keepalived
       apt:
         name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev']

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -1,10 +1,78 @@
 ---
+- name: assert that keepalived_version is defined
+  assert:
+    that:
+      - keepalived_version == 'distro' or keepalived_version is version('0.0.0', '>', strict=True)
+    fail_msg: keepalived_version must either be 'distro' or valid version number
+
 - name: install haproxy and keepalived
   package:
-    name: ['haproxy', 'keepalived']
+    name: haproxy
     state: present
   register: result
   until: result is succeeded
+
+- name: install keepalived
+  package:
+    name: keepalived
+    state: present
+  register: result
+  when: keepalived_version == 'distro'
+  until: result is succeeded
+
+- name: check if specified keepalived version already exists
+  command: "ls /usr/sbin/keepalived-{{ keepalived_version }}"
+  failed_when: false
+  changed_when: false
+  register: check_keepalived_version
+  when:
+
+- name: install required packages for keepalived
+  apt:
+    name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev' ]
+    state: present
+  when:
+    - keepalived_version is defined
+    - keepalived_version != 'distro'
+
+- name: unarchive keepalived
+  unarchive:
+    src: "{{ keepalived_url }}"
+    dest: /tmp/
+    remote_src: true
+    owner: root
+    group: root
+  when:
+    - keepalived_version is defined
+    - keepalived_version != 'distro'
+
+- name: build keepalived
+  command: "./configure --prefix=/usr/sbin/keepalived-{{ keepalived_version }}"
+  args:
+    chdir: "/tmp/keepalived-{{ keepalived_version }}/"
+  when:
+    - check_keepalived_version.rc != 0
+    - keepalived_version is defined
+    - keepalived_version != 'distro'
+
+- name: install keepalived
+  make:
+    chdir: "/tmp/keepalived-{{ keepalived_version }}/"
+    target: install
+  when:
+    - check_keepalived_version.rc != 0
+    - keepalived_version is defined
+    - keepalived_version != 'distro'
+
+- name: update binary to updated keepalived version
+  file:
+    path: /usr/sbin/keepalived
+    src: "/usr/sbin/keepalived-{{ keepalived_version }}/sbin/keepalived"
+    state: link
+    force: true
+  when:
+    - keepalived_version is defined
+    - keepalived_version != 'distro'
 
 - name: "generate haproxy configuration file: haproxy.cfg"
   template:


### PR DESCRIPTION
**Summary**

Currently there are no options to install specific version of keepalived and the version included in Ubuntu is outdated.

Add option for non-distro installation of keepalived from source.

**Tests**
```
PLAY RECAP ********************************************************************************************
controller001-stg.core-x.net : ok=91   changed=3    unreachable=0    failed=0    skipped=189  rescued=0    ignored=0
controller002-stg.core-x.net : ok=259  changed=6    unreachable=0    failed=0    skipped=383  rescued=0    ignored=0
controller003-stg.core-x.net : ok=240  changed=5    unreachable=0    failed=0    skipped=362  rescued=0    ignored=0
controller004-stg.core-x.net : ok=296  changed=6    unreachable=0    failed=0    skipped=430  rescued=0    ignored=0
storage001-stg             : ok=0    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
storage001-stg.core-x.net  : ok=97   changed=2    unreachable=0    failed=0    skipped=201  rescued=0    ignored=0
storage002-stg             : ok=0    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
storage002-stg.core-x.net  : ok=93   changed=1    unreachable=0    failed=0    skipped=197  rescued=0    ignored=0
storage003-stg             : ok=0    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
storage003-stg.core-x.net  : ok=93   changed=1    unreachable=0    failed=0    skipped=197  rescued=0    ignored=0
```
Confirmed keepalived is running on newest version:
```
stanleylam@controller002-stg:~$ sudo systemctl status keepalived
● keepalived.service - Keepalive Daemon (LVS and VRRP)
   Loaded: loaded (/lib/systemd/system/keepalived.service; enabled; vendor preset: enabled)
  Drop-In: /etc/systemd/system/keepalived.service.d
           └─override.conf
   Active: active (running) since Fri 2019-12-20 00:44:44 SAST; 16h ago
 Main PID: 3869603 (keepalived)
    Tasks: 2 (limit: 7372)
   CGroup: /system.slice/keepalived.service
           ├─3869603 /usr/sbin/keepalived
           └─3869604 /usr/sbin/keepalived

Dec 20 00:44:44 controller002-stg Keepalived_vrrp[3869604]: (VI_1) Entering BACKUP STATE (init)
Dec 20 00:44:44 controller002-stg Keepalived_vrrp[3869604]: VRRP_Script(check_haproxy) succeeded
Dec 20 00:44:44 controller002-stg Keepalived_vrrp[3869604]: (VI_0) received lower priority (90) advert
Dec 20 00:44:44 controller002-stg Keepalived_vrrp[3869604]: (VI_1) received lower priority (90) advert
Dec 20 00:44:45 controller002-stg Keepalived_vrrp[3869604]: (VI_0) received lower priority (90) advert
Dec 20 00:44:45 controller002-stg Keepalived_vrrp[3869604]: (VI_1) received lower priority (90) advert
Dec 20 00:44:46 controller002-stg Keepalived_vrrp[3869604]: (VI_0) received lower priority (90) advert
Dec 20 00:44:46 controller002-stg Keepalived_vrrp[3869604]: (VI_1) received lower priority (90) advert
Dec 20 00:44:47 controller002-stg Keepalived_vrrp[3869604]: (VI_0) Entering MASTER STATE
Dec 20 00:44:47 controller002-stg Keepalived_vrrp[3869604]: (VI_1) Entering MASTER STATE
```
```
stanleylam@controller002-stg:~$ keepalived --version
Keepalived v2.0.19 (10/19,2019)

Copyright(C) 2001-2019 Alexandre Cassen, <acassen@gmail.com>

Built with kernel headers for Linux 4.15.18
Running on Linux 5.0.0-36-generic #39~18.04.1-Ubuntu SMP Tue Nov 12 11:09:50 UTC 2019
...
```
