### PR TITLE
CLD-801 Add keepalived installation for RHEL

### DIFF
--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -17,7 +17,6 @@
     name: keepalived
     state: present
   register: result
-  when: keepalived_version == 'distro'
   until: result is succeeded
 
 - name: install non-distro version of keepalived

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -23,10 +23,17 @@
 - name: install non-distro version of keepalived
   block:
 
-    - name: install required packages for keepalived
+    - name: install required packages for keepalived on debian
       apt:
         name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev']
         state: present
+      when: ansible_os_family == 'Debian'
+
+    - name: install required packages for keepalived on redhat
+      yum:
+        name: ['curl', 'gcc', 'openssl-devel', 'libnl3-devel', 'net-snmp-devel']
+        state: present
+      when: ansible_os_family == 'RedHat'
 
     - name: check if specified keepalived version already exists
       command: "ls /usr/sbin/keepalived-{{ keepalived_version }}"


### PR DESCRIPTION
**Summary**

Add installation for RHEL or Debian based on installed OS.

Removed condition for keepalived distro version install because systemd service file is not automatically generated during version install.

**Tests**

Removed `/lib/systemd/system/keepalived.service` and removed keepalived package. Ran playbook and confirmed service running on newest version using `keepalived.service`.
