### PR TITLE
Enable haproxy stats for haproxy exporter

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -8,6 +8,7 @@
 keepalived_url: "https://www.keepalived.org/software/keepalived-{{ keepalived_version }}.tar.gz"
 keepalived_version: distro
 
+haproxy_exporter_stats: false
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_termination: False

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -8,7 +8,7 @@ global
     user        haproxy
     group       haproxy
     daemon
-    stats socket /var/lib/haproxy/stats
+    stats socket {% if haproxy_exporter_stats %}/run/haproxy/admin.sock mode 660 level admin{% else %}/var/lib/haproxy/stats{% endif %}
 {% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
     tune.ssl.default-dh-param 4096
     ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -8,7 +8,10 @@ global
     user        haproxy
     group       haproxy
     daemon
-    stats socket {% if haproxy_exporter_stats %}/run/haproxy/admin.sock mode 660 level admin{% else %}/var/lib/haproxy/stats{% endif %}
+{% if haproxy_exporter_stats %}
+    stats socket /run/haproxy/admin.sock mode 660 level admin
+{% else %}
+    stats socket /var/lib/haproxy/stats{% endif %}
 {% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
     tune.ssl.default-dh-param 4096
     ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM


### PR DESCRIPTION
**Summary**

Currently the haproxy configuration file does not have the ability to enable stats for haproxy exporter. Add configuration to allow this based on haproxy exporter's documentation.

**Tests**

<img width="459" alt="Screen Shot 2020-03-02 at 8 46 21 AM" src="https://user-images.githubusercontent.com/45326998/75697728-5ae92280-5c62-11ea-96e0-393125cc0d08.png">