### PR TITLE
Configure haproxy stats socket permissions

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -12,9 +12,8 @@ haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_termination: False
 
-haproxy_stats_socket_enabled: false
-haproxy_stats_socket_group: haproxy
-haproxy_stats_socket_mode: '0660'
+haproxy_stats_socket_group: root
+haproxy_stats_socket_mode: '0755'
 
 #virtual_ips:
 #  - address: 192.168.238.250

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -12,6 +12,10 @@ haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_termination: False
 
+haproxy_stats_socket_enabled: false
+haproxy_stats_socket_group: haproxy
+haproxy_stats_socket_mode: '0660'
+
 #virtual_ips:
 #  - address: 192.168.238.250
 #    netmask: 24

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -8,8 +8,9 @@ global
     user        haproxy
     group       haproxy
     daemon
-    stats socket /var/lib/haproxy/stats
+    stats socket /var/lib/haproxy/stats {% if haproxy_stats_socket_enabled %}mode {{ haproxy_stats_socket_mode }} group {{ haproxy_stats_socket_group }}{% endif %}
 {% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
+
     tune.ssl.default-dh-param 4096
     ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM
     ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -8,7 +8,7 @@ global
     user        haproxy
     group       haproxy
     daemon
-    stats socket /var/lib/haproxy/stats {% if haproxy_stats_socket_enabled %}mode {{ haproxy_stats_socket_mode }} group {{ haproxy_stats_socket_group }}{% endif %}
+    stats socket /var/lib/haproxy/stats mode {{ haproxy_stats_socket_mode }} group {{ haproxy_stats_socket_group }}
 {% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
 
     tune.ssl.default-dh-param 4096

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -10,7 +10,6 @@ global
     daemon
     stats socket /var/lib/haproxy/stats mode {{ haproxy_stats_socket_mode }} group {{ haproxy_stats_socket_group }}
 {% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
-
     tune.ssl.default-dh-param 4096
     ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM
     ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets


### PR DESCRIPTION
**Summary**

Currently haproxy's configuration does not provide the correct permissions for the `/var/lib/haproxy/stat` file required for haproxy-exporter.

Configure the permissions for `/var/lib/haproxy/stat` file for haproxy-exporter.

**Tests**

Confirmed that the template generated is correct:
```
global
    log         127.0.0.1 local2

    chroot      /var/lib/haproxy
    pidfile     /var/run/haproxy.pid
    maxconn     8000
    user        haproxy
    group       haproxy
    daemon
    stats socket /var/lib/haproxy/stats mode 0660 group haproxy
    tune.ssl.default-dh-param 4096
    ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM
    ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
```

Confirmed that haproxy-exporter is able to scrape metrics from haproxy:
```
stanleylam@controller001-dev:~$ curl -s localhost:9101/metrics | grep haproxy_up
# HELP haproxy_up Was the last scrape of haproxy successful.
# TYPE haproxy_up gauge
haproxy_up 1
```