### PR TITLE
Enable HAProxy backend checks for Ceph RGW

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -44,9 +44,8 @@ frontend rgw-frontend
 backend rgw-backend
     option forwardfor
     balance static-rr
-    option httpchk Get /
 {% for host in groups[rgw_group_name] %}
 {% for instance in hostvars[host]['rgw_instances'] %}
-	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100
+	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100 check
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Currently HAProxy does not have health checks enabled for the RGW backend servers. Thus traffic is still sent to offline RADOS gateway services.

Enable health checks for backend rgw servers.

Example found in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/load_balancer_administration/install_haproxy_example1