### PR TITLE
CLD-1055 ceph-rgw-loadbalancer: Add haproxy stat socket permissions

### DIFF
--- a/group_vars/rgwloadbalancers.yml.sample
+++ b/group_vars/rgwloadbalancers.yml.sample
@@ -25,6 +25,8 @@ dummy:
 #  - no-tlsv10
 #  - no-tlsv11
 #  - no-tls-tickets
+#haproxy_stats_socket_group: root
+#haproxy_stats_socket_mode: '0755'
 #
 #virtual_ips:
 #   - 192.168.238.250

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -17,6 +17,8 @@ haproxy_ssl_options:
   - no-tlsv10
   - no-tlsv11
   - no-tls-tickets
+haproxy_stats_socket_group: root
+haproxy_stats_socket_mode: '0755'
 #
 #virtual_ips:
 #   - 192.168.238.250

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -8,7 +8,7 @@ global
     user        haproxy
     group       haproxy
     daemon
-    stats socket /var/lib/haproxy/stats
+    stats socket /var/lib/haproxy/stats mode {{ haproxy_stats_socket_mode }} group {{ haproxy_stats_socket_group }}
 {% if haproxy_frontend_ssl_certificate %}
     tune.ssl.default-dh-param {{ haproxy_ssl_dh_param }}
     ssl-default-bind-ciphers {{ haproxy_ssl_ciphers | join(':') }}


### PR DESCRIPTION
Add ability to configure haproxy stat socket permission for use with haproxy-exporter.

These changes are from upstream PR https://github.com/ceph/ceph-ansible/pull/5120