### PR TITLE
CLD-1055 Enable HAProxy backend checks for Ceph RGW

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -43,9 +43,8 @@ frontend rgw-frontend
 backend rgw-backend
     option forwardfor
     balance static-rr
-    option httpchk Get /
 {% for host in groups[rgw_group_name] %}
 {% for instance in hostvars[host]['rgw_instances'] %}
-	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100
+	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100 check
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Add the [`check`](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-check) option to server definitions to enable basic HAProxy health checks for Ceph RADOS gateway backends.

Currently traffic will be forwarded to offline `radosgw` services. These changes resolve the issue.

These changes are from upstream PR https://github.com/ceph/ceph-ansible/pull/5126