### PR TITLE
CLD-1039 Add HAProxy frontend terminal for RGW

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -119,7 +119,7 @@ log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname']
 {%- if frontend_type == 'civetweb' -%}
 {{ radosgw_frontend_type }} port={{ _rgw_binding_socket }}{{ 's ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate else '' }}
 {%- elif frontend_type == 'beast' -%}
-{{ radosgw_frontend_type }} {{ 'ssl_' if radosgw_frontend_ssl_certificate else '' }}endpoint={{ _rgw_binding_socket }}{{ ' ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate else '' }}
+{{ radosgw_frontend_type }} {{ 'ssl_' if radosgw_frontend_ssl_certificate and not haproxy_frontend_ssl_termination else '' }}endpoint={{ _rgw_binding_socket }}{{ ' ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate and not haproxy_frontend_ssl_termination else '' }}
 {%- endif -%}
 {%- endmacro -%}
 rgw frontends = {{ frontend_line(radosgw_frontend_type) }} {{ radosgw_frontend_options }}

--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -5,7 +5,8 @@ DELAY="{{ handler_health_rgw_check_delay }}"
 HOST_NAME="{{ ansible_hostname }}"
 RGW_NUMS={{ rgw_instances | length | int }}
 RGW_FRONTEND_SSL_CERT={{ radosgw_frontend_ssl_certificate }}
-if [ -n "$RGW_FRONTEND_SSL_CERT" ]; then
+RGW_HAPROXY_SSL_TERMINATION={{ haproxy_frontend_ssl_termination }}
+if [ -n "$RGW_FRONTEND_SSL_CERT" ] && [ $RGW_HAPROXY_SSL_TERMINATION == 'False' ]; then
     RGW_PROTOCOL=https
 else
     RGW_PROTOCOL=http

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -7,6 +7,7 @@
 
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
+haproxy_frontend_ssl_termination: False
 haproxy_frontend_ssl_certificate:
 haproxy_ssl_dh_param: 4096
 haproxy_ssl_ciphers:

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -33,7 +33,7 @@ defaults
     maxconn                 8000
 
 frontend rgw-frontend
-{% if hhaproxy_frontend_ssl_termination and proxy_frontend_ssl_certificate %}
+{% if haproxy_frontend_ssl_termination and haproxy_frontend_ssl_certificate %}
     bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ haproxy_frontend_ssl_certificate }}
 {% else %}
     bind *:{{ haproxy_frontend_port }}

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -33,8 +33,8 @@ defaults
     maxconn                 8000
 
 frontend rgw-frontend
-{% if haproxy_frontend_ssl_termination and haproxy_frontend_ssl_certificate %}
-    bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ haproxy_frontend_ssl_certificate }}
+{% if haproxy_frontend_ssl_termination and radosgw_frontend_ssl_certificate %}
+    bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ radosgw_frontend_ssl_certificate }}
 {% else %}
     bind *:{{ haproxy_frontend_port }}
 {% endif %}

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -33,7 +33,7 @@ defaults
     maxconn                 8000
 
 frontend rgw-frontend
-{% if haproxy_frontend_ssl_certificate %}
+{% if hhaproxy_frontend_ssl_termination and proxy_frontend_ssl_certificate %}
     bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ haproxy_frontend_ssl_certificate }}
 {% else %}
     bind *:{{ haproxy_frontend_port }}

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -30,7 +30,7 @@ vrrp_instance {{ instance['name'] }} {
     }
 {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
     virtual_routes {
-  {%- for source in instance['virtual_route_source'] %}
+  {%- for source in instance['virtual_route_source'] %} 
         {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}
   {%- endfor %}{{ '\n' }}    }
 {% endif %}


### PR DESCRIPTION
**Summary**

PR which was submitted to `stable-4.0` which features SSL termination using HAProxy instead of Ceph RGW. Based off: https://github.com/webnifico/ceph-ansible/pull/1. This PR never got pushed upstream but was being utilized by our fork.

**Tests**

Confirmed that HAProxy and ceph configuration files generate correct settings for HAProxy frontend SSL termination and removal of SSL frontend for Ceph RGW services.