### PR TITLE
CLD-1076 Add gratuitous arp configurations to keepalived

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -3,6 +3,9 @@
 
 global_defs {
    router_id CEPH_RGW
+   vrrp_garp_master_refresh 10
+   vrrp_garp_master_refresh_repeat 1
+   vrrp_garp_lower_prio_delay 1
 }
 
 vrrp_script check_haproxy {


### PR DESCRIPTION
**Summary**

Add gratuitous ARP configurations to keepalived to prevent rados gateway outage when rgw controller is restarted.