### PR TITLE
Add make package to ceph-rgw-loadbalancer role

### DIFF
--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -5,9 +5,9 @@
       - keepalived_version == 'distro' or keepalived_version is version('0.0.0', '>', strict=True)
     fail_msg: keepalived_version must either be 'distro' or valid version number
 
-- name: install haproxy and keepalived
+- name: install haproxy, keepalived, and make
   package:
-    name: ['haproxy', 'keepalived']
+    name: ['haproxy', 'keepalived', 'make']
     state: present
   register: result
   until: result is succeeded


### PR DESCRIPTION
**Summary**

Currently new deployments will fail during task: `[ceph-rgw-loadbalancer : install keepalived] `:
```
TASK [ceph-rgw-loadbalancer : install keepalived] ********************************************************************
Wednesday 22 April 2020  15:11:58 -0700 (0:00:10.248)       0:06:37.117 *******
fatal: [controller003]: FAILED! => {"changed": false, "msg": "Failed to find required executable make in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"}
fatal: [controller001]: FAILED! => {"changed": false, "msg": "Failed to find required executable make in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"}
fatal: [controller002]: FAILED! => {"changed": false, "msg": "Failed to find required executable make in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"}
```

Add `make` to the list of installed packages alongside with `haproxy` and `keepalived`.

**Tests**

Confirmed playbook able to pass this task without issues:
```
TASK [ceph-rgw-loadbalancer : install keepalived] ********************************************************************
Wednesday 22 April 2020  16:31:35 -0700 (0:00:10.406)       0:06:41.851 *******
changed: [controller003]
changed: [controller002]
changed: [controller001]
```