### PR TITLE
Fix httpchk for HAProxy backend services

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -46,6 +46,7 @@ frontend rgw-frontend
 backend rgw-backend
     option forwardfor
     balance static-rr
+    option httpchk GET /
 {% for host in groups[rgw_group_name] %}
 {% for instance in hostvars[host]['rgw_instances'] %}
 	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100 check

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -46,7 +46,7 @@ frontend rgw-frontend
 backend rgw-backend
     option forwardfor
     balance static-rr
-    option httpchk GET /
+    option httpchk HEAD /
 {% for host in groups[rgw_group_name] %}
 {% for instance in hostvars[host]['rgw_instances'] %}
 	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100 check


### PR DESCRIPTION
Revert https://github.com/webnifico/ceph-ansible/pull/13 while fixing `Get` -> `GET`.

We received feedback on upstream PR https://github.com/ceph/ceph-ansible/pull/5126 which suggests we can use HTTP checks instead of TCP checks by using a valid HTTP verb.

I've stopped the `ceph-radosgw.target` on servers (rotating through them) and confirmed the radosgw service is still available via HTTPS.