### PR TITLE
Install source Keepalived to the default make location

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -5,6 +5,7 @@
 # GENERAL #
 ###########
 
+keepalived_build_dir: /opt
 keepalived_url: "https://www.keepalived.org/software/keepalived-{{ keepalived_version }}.tar.gz"
 keepalived_version: distro
 

--- a/roles/ceph-rgw-loadbalancer/files/keepalived-override.conf
+++ b/roles/ceph-rgw-loadbalancer/files/keepalived-override.conf
@@ -1,0 +1,4 @@
+[Service]
+# Override binary location when building from source
+ExecStart=
+ExecStart=/usr/local/sbin/keepalived $DAEMON_ARGS

--- a/roles/ceph-rgw-loadbalancer/handlers/main.yml
+++ b/roles/ceph-rgw-loadbalancer/handlers/main.yml
@@ -1,10 +1,11 @@
 ---
 - name: restart haproxy
-  service:
+  systemd:
     name: haproxy
     state: restarted
 
 - name: restart keepalived
-  service:
+  systemd:
     name: keepalived
     state: restarted
+    daemon_reload: true

--- a/roles/ceph-rgw-loadbalancer/keepalived-override.conf
+++ b/roles/ceph-rgw-loadbalancer/keepalived-override.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStart=/usr/local/sbin/keepalived $DAEMON_ARGS

--- a/roles/ceph-rgw-loadbalancer/keepalived-override.conf
+++ b/roles/ceph-rgw-loadbalancer/keepalived-override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStart=/usr/local/sbin/keepalived $DAEMON_ARGS

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -14,7 +14,6 @@
 
 - name: install non-distro version of keepalived
   block:
-
     - name: install required packages for keepalived on debian
       apt:
         name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev']
@@ -28,39 +27,44 @@
       when: ansible_os_family == 'RedHat'
 
     - name: check if specified keepalived version already exists
-      command: "ls /usr/sbin/keepalived-{{ keepalived_version }}"
+      command: "ls {{ keepalived_build_dir }}/keepalived-{{ keepalived_version }}"
       failed_when: false
       changed_when: false
-      register: check_keepalived_version
+      register: _check_keepalived_version
 
     - name: unarchive keepalived
       unarchive:
         src: "{{ keepalived_url }}"
-        dest: /tmp/
+        dest: "{{ keepalived_build_dir }}/"
         remote_src: true
         owner: root
         group: root
-      when: check_keepalived_version.rc != 0
+      when: _check_keepalived_version.rc != 0
 
     - name: build keepalived
-      command: "./configure --prefix=/usr/sbin/keepalived-{{ keepalived_version }}"
+      command: './configure'
       args:
-        chdir: "/tmp/keepalived-{{ keepalived_version }}/"
-      when: check_keepalived_version.rc != 0
+        chdir: "{{ keepalived_build_dir }}/keepalived-{{ keepalived_version }}/"
+      when: _check_keepalived_version.rc != 0
 
     - name: install keepalived
       make:
-        chdir: "/tmp/keepalived-{{ keepalived_version }}/"
+        chdir: "{{ keepalived_build_dir }}/keepalived-{{ keepalived_version }}/"
         target: install
-      when: check_keepalived_version.rc != 0
-
-    - name: update binary to updated keepalived version
-      file:
-        path: /usr/sbin/keepalived
-        src: "/usr/sbin/keepalived-{{ keepalived_version }}/sbin/keepalived"
-        state: link
-        force: true
       notify: restart keepalived
+      when: _check_keepalived_version.rc != 0
+
+    - name: create systemd override directory
+      file:
+        path: /etc/systemd/system/keepalived.service.d
+        state: directory
+
+    - name: load systemd override file
+      copy:
+        src: keepalived-override.conf
+        dest: /etc/systemd/system/keepalived.service.d/override.conf
+      notify:
+        - restart keepalived
 
   when: keepalived_version != 'distro'
 


### PR DESCRIPTION
Instead of installing symlinks to `/usr/sbin/keepalived-keepalived*` we can run `./configure` without setting a `--prefix` option.

This installs Keepalived (by default) to `/usr/local/sbin/keepalived`.

We need to override the `ExecStart` in the default service file as well:

```
$ grep ExecStart /lib/systemd/system/keepalived.service
ExecStart=/usr/sbin/keepalived $DAEMON_ARGS
```

This can be accomplished with `/etc/systemd/system/keepalived.service.d/override.conf`.