### PR TITLE
CLD-1493 Add support for RGW monitor-uri healthcheck

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -5,6 +5,7 @@
 # GENERAL #
 ###########
 
+haproxy_frontend_healthcheck: false
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_certificate:

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -38,6 +38,9 @@ frontend rgw-frontend
 {% else %}
     bind *:{{ haproxy_frontend_port }}
 {% endif %}
+{% if haproxy_frontend_healthcheck %}
+    monitor-uri /swift/healthcheck
+{% endif %}
     default_backend rgw-backend
 
 backend rgw-backend


### PR DESCRIPTION
**Summary**

Use `monitor-uri` parameter to stop logging requests from Prometheus servers by using built-in RGW health check endpoint.