### PR TITLE
CLD-1493 Add support for RGW monitor-uri healthcheck

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -9,6 +9,7 @@ keepalived_build_dir: /opt
 keepalived_url: "https://www.keepalived.org/software/keepalived-{{ keepalived_version }}.tar.gz"
 keepalived_version: distro
 
+haproxy_frontend_healthcheck: false
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_termination: False

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -38,6 +38,9 @@ frontend rgw-frontend
 {% else %}
     bind *:{{ haproxy_frontend_port }}
 {% endif %}
+{% if haproxy_frontend_healthcheck %}
+    monitor-uri /swift/healthcheck
+{% endif %}
     default_backend rgw-backend
 
 backend rgw-backend


### PR DESCRIPTION
Summary

Use `monitor-uri` parameter to stop logging requests from Prometheus servers by using built-in RGW health check endpoint.