### PR TITLE
Reload haproxy if configured for SSL termination

### DIFF
--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -4,6 +4,11 @@
     name: "ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}"
     state: restarted
   with_items: "{{ rgw_instances }}"
+
+- name: restart ceph rgws check
+  debug:
+    msg: "notify restart ceph rgws"
+  notify: restart ceph rgws
   when: not haproxy_frontend_ssl_termination
 
 - name: reload haproxy

--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -9,4 +9,3 @@
   service:
     name: haproxy
     state: reloaded
-  when: haproxy_frontend_ssl_termination

--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -4,3 +4,10 @@
     name: "ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}"
     state: restarted
   with_items: "{{ rgw_instances }}"
+  when: not haproxy_frontend_ssl_termination
+
+- name: reload haproxy
+  service:
+    name: haproxy
+    state: reloaded
+  when: haproxy_frontend_ssl_termination

--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -5,12 +5,6 @@
     state: restarted
   with_items: "{{ rgw_instances }}"
 
-- name: restart ceph rgws check
-  debug:
-    msg: "notify restart ceph rgws"
-  notify: restart ceph rgws
-  when: not haproxy_frontend_ssl_termination
-
 - name: reload haproxy
   service:
     name: haproxy

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -33,14 +33,28 @@
     - item is not skipped
     - item.item.copy_key | bool
 
-- name: copy SSL certificate & key data to certificate path
+- name: copy SSL certificate & key data to certificate path for rgw
   copy:
     content: "{{ radosgw_frontend_ssl_certificate_data }}"
     dest: "{{ radosgw_frontend_ssl_certificate }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: 0440
-  when: radosgw_frontend_ssl_certificate | length > 0 and radosgw_frontend_ssl_certificate_data | length > 0
-  notify:
-    - restart ceph rgws check
-    - reload haproxy
+  when:
+    - radosgw_frontend_ssl_certificate | length > 0
+    - radosgw_frontend_ssl_certificate_data | length > 0
+    - not haproxy_frontend_ssl_termination
+  notify: restart ceph rgws
+
+- name: copy SSL certificate & key data to certificate path for haproxy
+  copy:
+    content: "{{ radosgw_frontend_ssl_certificate_data }}"
+    dest: "{{ radosgw_frontend_ssl_certificate }}"
+    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    mode: 0440
+  when:
+    - radosgw_frontend_ssl_certificate | length > 0
+    - radosgw_frontend_ssl_certificate_data | length > 0
+    - haproxy_frontend_ssl_termination
+  notify: reload haproxy

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -41,4 +41,6 @@
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: 0440
   when: radosgw_frontend_ssl_certificate | length > 0 and radosgw_frontend_ssl_certificate_data | length > 0
-  notify: restart ceph rgws
+  notify:
+    - restart ceph rgws
+    - reload haproxy

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -42,5 +42,5 @@
     mode: 0440
   when: radosgw_frontend_ssl_certificate | length > 0 and radosgw_frontend_ssl_certificate_data | length > 0
   notify:
-    - restart ceph rgws
+    - restart ceph rgws check
     - reload haproxy


### PR DESCRIPTION
**Summary**

Currently the **ceph-rgw** role does not support reloading **haproxy.service** when SSL certificate is updated haproxy is configured for SSL termination instead of Ceph RGW.

Add handler to accommodate reloading haproxy if SSL certificate is changed and haproxy is configured for SSL termination.

Add handler for the purpose of checking this condition before forwarding to main handler.

**Tests**

Confirmed haproxy is reloaded when SSL certificate changed.
Refer to ticket for test results.