### PR TITLE
CLD-1716 Add SSL directory if it doesnt exist

### DIFF
--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -36,7 +36,7 @@
 - name: copy SSL certificate & key data to certificate path for rgw
   copy:
     content: "{{ radosgw_frontend_ssl_certificate_data }}"
-    dest: "{{ radosgw_frontend_ssl_certificate }}"
+    dest: "{{ radosgw_frontend_ssl_certificate | regex_replace('[^/]*$')  }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: 0440

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -36,7 +36,7 @@
 - name: copy SSL certificate & key data to certificate path for rgw
   copy:
     content: "{{ radosgw_frontend_ssl_certificate_data }}"
-    dest: "{{ radosgw_frontend_ssl_certificate | regex_replace('[^/]*$')  }}"
+    dest: "{{ radosgw_frontend_ssl_certificate }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: 0440
@@ -48,7 +48,7 @@
 
 - name: create SSL directory if it doesnt exist
   file:
-    path: "{{ radosgw_frontend_ssl_certificate }}"
+    path: "{{ radosgw_frontend_ssl_certificate | regex_replace('[^/]*$') }}"
     state: directory
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "0640"

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -46,6 +46,13 @@
     - not haproxy_frontend_ssl_termination
   notify: restart ceph rgws
 
+- name: create SSL directory if it doesnt exist
+  file:
+    path: "{{ radosgw_frontend_ssl_certificate }}"
+    state: directory
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    mode: "0640"
+
 - name: copy SSL certificate & key data to certificate path for haproxy
   copy:
     content: "{{ radosgw_frontend_ssl_certificate_data }}"


### PR DESCRIPTION
Currently the Ceph playbook fails on new builds due to the fact that the SSL directory has not been created yet. 

This PR creates the directory before copying the SSL certificate into it.

**Tests**
Before:
```
TASK [ceph-rgw : copy SSL certificate & key data to certificate path for haproxy] ***
Tuesday 16 February 2021  15:47:21 +0200 (0:00:00.208)       0:09:29.075 ****** 
ok: [controller002-stg.core-x.net]
ok: [controller003-stg.core-x.net]
fatal: [controller004-stg.core-x.net]: FAILED! => {"changed": false, "checksum": "fb3e39458bdb3234277d33f84fc83a7c257521ad", "msg": "Destination directory /etc/ssl/core-x.net does not exist"}
```

After:
```
TASK [ceph-rgw : create SSL directory if it doesnt exist] **********************
Wednesday 17 February 2021  13:48:48 +0200 (0:00:00.205)       0:05:48.824 **** 
ok: [controller002-stg.core-x.net]
ok: [controller003-stg.core-x.net]
changed: [controller004-stg.core-x.net]
TASK [ceph-rgw : copy SSL certificate & key data to certificate path for haproxy] ***
Wednesday 17 February 2021  13:48:48 +0200 (0:00:00.448)       0:05:49.273 **** 
ok: [controller002-stg.core-x.net]
changed: [controller004-stg.core-x.net]
ok: [controller003-stg.core-x.net]
```