### PR TITLE
Reload haproxy only if the service exists

### DIFF
--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -9,4 +9,4 @@
   service:
     name: haproxy
     state: reloaded
-  when: haproxy_service_file.exists
+  when: haproxy_service_file.stat.exists

--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -9,4 +9,4 @@
   service:
     name: haproxy
     state: reloaded
-  when: haproxy_service_status.exists
+  when: haproxy_service_file.exists

--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -9,3 +9,4 @@
   service:
     name: haproxy
     state: reloaded
+  when: haproxy_service_status.exists

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -33,6 +33,11 @@
     - item is not skipped
     - item.item.copy_key | bool
 
+- name: check if haproxy is deployed
+  stat:
+    path: /lib/systemd/system/haproxy.service
+  register: haproxy_service_status
+
 - name: copy SSL certificate & key data to certificate path for rgw
   copy:
     content: "{{ radosgw_frontend_ssl_certificate_data }}"

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -36,7 +36,7 @@
 - name: check if haproxy is deployed
   stat:
     path: /lib/systemd/system/haproxy.service
-  register: haproxy_service_status
+  register: haproxy_service_file
 
 - name: copy SSL certificate & key data to certificate path for rgw
   copy:


### PR DESCRIPTION
**Summary**

Currently during new deployments, the handler to reload **haproxy.service** will execute even when **haproxy.service** has not yet been deployed resulting in an error.

Add task to check if **haproxy.service** has been deployed, and only execute the handler when **haproxy.service** is deployed.